### PR TITLE
make rspec and yard inclusion optional and do not install in production/stage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,12 +18,19 @@ gem 'sdoc', '~> 0.4.0',          group: :doc
 gem 'spring',        group: :development
 
 gem 'nokogiri'
-gem "rspec"
-gem 'rspec-rails'
+
 gem 'rest-client'
-gem 'equivalent-xml'
 gem 'coveralls', require: false
-gem 'yard'
+
+group :development do
+  gem 'yard'
+end
+
+group :test do
+  gem "rspec"
+  gem 'rspec-rails'
+  gem 'equivalent-xml'
+end
 
 group :deployment do
   gem 'capistrano'

--- a/Gemfile
+++ b/Gemfile
@@ -15,21 +15,20 @@ gem 'turbolinks'
 gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0',          group: :doc
 
-gem 'spring',        group: :development
-
 gem 'nokogiri'
 
 gem 'rest-client'
-gem 'coveralls', require: false
 
 group :development do
+  gem 'spring'
   gem 'yard'
 end
 
 group :test do
+  gem 'coveralls', require: false
+  gem 'equivalent-xml'
   gem "rspec"
   gem 'rspec-rails'
-  gem 'equivalent-xml'
 end
 
 group :deployment do

--- a/Gemfile
+++ b/Gemfile
@@ -13,13 +13,13 @@ gem 'execjs'
 gem 'jquery-rails'
 gem 'turbolinks'
 gem 'jbuilder', '~> 2.0'
-gem 'sdoc', '~> 0.4.0',          group: :doc
 
 gem 'nokogiri'
 
 gem 'rest-client'
 
 group :development do
+  gem 'sdoc', '~> 0.4.0'
   gem 'spring'
   gem 'yard'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :deployment do
   gem 'capistrano'
   gem 'capistrano-rvm'
   gem 'capistrano-bundler'
+  gem 'capistrano-passenger'
   gem 'capistrano-rails'
   gem 'dlss-capistrano'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,8 @@ GEM
     capistrano-harrow (0.5.2)
     capistrano-one_time_key (0.0.1)
       capistrano (~> 3.0)
+    capistrano-passenger (0.2.0)
+      capistrano (~> 3.0)
     capistrano-rails (1.1.7)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
@@ -214,6 +216,7 @@ PLATFORMS
 DEPENDENCIES
   capistrano
   capistrano-bundler
+  capistrano-passenger
   capistrano-rails
   capistrano-rvm
   coffee-rails (~> 4.0.0)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -4,7 +4,7 @@ set :repo_url, 'https://github.com/sul-dlss/was-registrar.git'
 set :stages, %W(stage development production)
 
 # Default branch is :master
-# ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call
+ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call
 
 # Default deploy_to directory is /var/www/my_app
 set :deploy_to, '/opt/app/was/was-registrar'

--- a/config/deploy/development.rb
+++ b/config/deploy/development.rb
@@ -2,4 +2,5 @@ server 'was-registrar-dev.stanford.edu', user: 'was', roles: %w{web app db}
 
 Capistrano::OneTimeKey.generate_one_time_key!
 
+set :bundle_without, %w{deployment test}.join(' ')
 set :deploy_environment, 'development'

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -2,4 +2,5 @@ server 'was-registrar-dev.stanford.edu', user: 'was', roles: %w{web app db}
 
 Capistrano::OneTimeKey.generate_one_time_key!
 
+set :bundle_without, %w{deployment development test}.join(' ')
 set :deploy_environment, 'production'

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -2,4 +2,5 @@ server 'was-registrar-dev.stanford.edu', user: 'was', roles: %w{web app db}
 
 Capistrano::OneTimeKey.generate_one_time_key!
 
+set :bundle_without, %w{deployment development test}.join(' ')
 set :deploy_environment, 'production'


### PR DESCRIPTION
The goal of this PR is to exclude the `test` and `development` gems from our stage/prod deployments. That involves making rspec and yard optional in the Rakefile. I wasn't able to test this because deploys are broken on master right now.

Connects to #18