### PR TITLE
Add stacktrace on failure and only catch RestClient exceptions

### DIFF
--- a/lib/was/registrar/register_crawl_object_from_file.rb
+++ b/lib/was/registrar/register_crawl_object_from_file.rb
@@ -2,7 +2,7 @@ module Was
   module Registrar
     # Registers a set of crawl objects defined by an input file
     class RegisterCrawlObjectFromFile
-      
+
       # Registers the items in the input_file_path and log the errors in log_file
       # @example file format:
       #   Source_id job_directory collection_id
@@ -28,7 +28,9 @@ module Was
             success_count += 1
           rescue => e
             puts "Error in registering #{line} with #{e.inspect}"
+            puts e.backtrace.join("\n") unless e.backtrace.nil?
             logger.fatal "Error in registering #{line} with #{e.inspect}"
+            logger.fatal e.backtrace.join("\n") unless e.backtrace.nil?
             fail_count += 1
           end
         end
@@ -42,7 +44,7 @@ module Was
         job_directory = fields[1]
         collection_id = fields[2]
         apo_id = fields[3]
-        
+
         return { 'source_id' => source_id, 'job_directory' => job_directory, 'collection_id' => collection_id, 'apo_id' => apo_id }
       end
 

--- a/lib/was/registrar/register_object.rb
+++ b/lib/was/registrar/register_object.rb
@@ -31,8 +31,9 @@ module Was
         begin
           response = RestClient.post(Rails.configuration.service_root,  register_params, timeout: 60, open_timeout: 60)
           code = response.code
-         rescue => e
-           raise 'Error in registring the object. ' + e.message
+        rescue RestClient::Exception => e
+          Rails.logger.error 'Error in registring the object. ' + e.message
+          raise
         end
 
         druid = response.body

--- a/spec/registrar/register_crawl_object_from_file_spec.rb
+++ b/spec/registrar/register_crawl_object_from_file_spec.rb
@@ -57,7 +57,8 @@ describe Was::Registrar::RegisterCrawlObjectFromFile do
       valid_file = "#{@fixtures}register_crawl_files/valid_one_line.txt"
       allow(Was::Registrar::RegisterCrawlObjectFromFile).to receive(:verify_file).and_return(true)
       expect(Was::Registrar::RegisterCrawlObjectFromFile).to receive(:convert_line_to_hash).and_return(nil)
-      expect_any_instance_of(Logger).to receive(:fatal).with("Error in registering WAS:Test\tjob1/warc\tdruid:ab123cd4567\tdruid:mn123pq4567 with #<NoMethodError: undefined method `[]' for nil:NilClass>")
+      expect_any_instance_of(Logger).to receive(:fatal).with(/Error in registering/)
+      expect_any_instance_of(Logger).to receive(:fatal).with(/was-registrar\/lib\/was\/registrar\/register_crawl_object.rb:/) # stack trace
       Was::Registrar::RegisterCrawlObjectFromFile.register(valid_file, 'log/tmp.txt')
     end
   end


### PR DESCRIPTION
This PR adds the stacktrace to the log output when registration fails, and it only catches `RestClient::Exception` exceptions rather than all of `StandardError`.

Connects to #13