### PR TITLE
explicitly set the RAILS_ENV to production for stage

### DIFF
--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -4,3 +4,4 @@ Capistrano::OneTimeKey.generate_one_time_key!
 
 set :bundle_without, %w{deployment development test}.join(' ')
 set :deploy_environment, 'production'
+set :rails_env, fetch(:deploy_environment)


### PR DESCRIPTION
Without this the `assets:precompile` fails when deploying to stage.