### PR TITLE
use RestClient::Resource.new before POST

### DIFF
--- a/lib/was/registrar/register_object.rb
+++ b/lib/was/registrar/register_object.rb
@@ -29,10 +29,14 @@ module Was
       def register_object_using_web_service(register_params)
         Rails.logger.debug "Registering an object with params #{register_params}"
         begin
-          response = RestClient.post(Rails.configuration.service_root,  register_params, timeout: 300, open_timeout: 60)
+          resource = RestClient::Resource.new(
+            Rails.configuration.service_root, timeout: 300, open_timeout: 60
+          )
+          response = resource.post(register_params)
+          Rails.logger.debug response.inspect
           code = response.code
         rescue RestClient::Exception => e
-          Rails.logger.error 'Error in registring the object. ' + e.message
+          Rails.logger.error 'Error in registering the object. ' + e.message
           raise
         end
 

--- a/spec/registrar/register_object_spec.rb
+++ b/spec/registrar/register_object_spec.rb
@@ -17,27 +17,26 @@ describe Was::Registrar::RegisterSeedObject do
       response = double('net http response', to_hash: { 'Status' => ['200 OK'] }, code: 200, body: 'druid:aa111aa1111')
 
       registrar = Was::Registrar::RegisterObject.new
-      allow(RestClient).to receive(:post).and_return(response)
-      expect(RestClient).to receive(:post).with('https://registr.stanford.edu/', params, timeout: 300, open_timeout: 60)
+      expect_any_instance_of(RestClient::Resource).to receive(:post).with(params).and_return(response)
       expect(registrar.register_object_using_web_service(params)).to eq('druid:aa111aa1111')
     end
     it 'should raise an error if the response is not valid druid' do
       params = {}
       response = double('net http response', to_hash: { 'Status' => ['200 OK'] }, code: 200, body: 'not_valid_druid')
       registrar = Was::Registrar::RegisterObject.new
-      expect(RestClient).to receive(:post).and_return(response)
+      expect_any_instance_of(RestClient::Resource).to receive(:post).with(params).and_return(response)
       expect { registrar.register_object_using_web_service(params) }.to raise_error(RuntimeError, /Error in registring the object/)
     end
     it 'should raise an error if the client connection fails' do
       params = {}
-      expect(RestClient).to receive(:post).and_raise(RestClient::Exception)
+      expect_any_instance_of(RestClient::Resource).to receive(:post).with(params).and_raise(RestClient::Exception)
       registrar = Was::Registrar::RegisterObject.new
       expect_any_instance_of(Logger).to receive(:error).once
       expect { registrar.register_object_using_web_service(params) }.to raise_error(RestClient::Exception)
     end
     it 'should raise an error on an unexpected exception' do
       params = {}
-      expect(RestClient).to receive(:post).and_raise(RuntimeError)
+      expect_any_instance_of(RestClient::Resource).to receive(:post).with(params).and_raise(RuntimeError)
       registrar = Was::Registrar::RegisterObject.new
       expect_any_instance_of(Logger).not_to receive(:error)
       expect { registrar.register_object_using_web_service(params) }.to raise_error(RuntimeError)


### PR DESCRIPTION
This PR fixes the old code that ignored the timeout values.