### PR TITLE
add explicit failures with APO data is incomplete

### DIFF
--- a/lib/was/utilities/dor_utilities.rb
+++ b/lib/was/utilities/dor_utilities.rb
@@ -10,9 +10,10 @@ module Was
         apos_list = get_apos_list
         apos_list.each do |apo|
           apo_info_json = read_apo_data apo
-          next if apo_info_json.nil?
-
+          next if apo_info_json.nil? # TODO: shouldn't this raise an exception?
           collections_list = parse_collection_json(apo_info_json['collections'])
+
+          fail "Missing adminpolicies for APO #{apo}: #{apo_info_json.inspect}" unless apo_info_json['adminpolicies'].present?
           apo_title = apo_info_json['adminpolicies'].first['title'].sub('Web Archive ','')
 
           apo_record = { apo_druid: apo,
@@ -28,9 +29,11 @@ module Was
         apos_list = get_apos_list
         apos_list.each do |apo|
           apo_info_json = read_apo_data apo
-          next if apo_info_json.nil?
+          next if apo_info_json.nil? # TODO: shouldn't this raise an exception?
 
           items_list = parse_items_json(apo_info_json['items'])
+
+          fail "Missing adminpolicies for APO #{apo}: #{apo_info_json.inspect}" unless apo_info_json['adminpolicies'].present?
           apo_title = apo_info_json['adminpolicies'].first['title'].sub('Web Archive ','')
 
           apo_record = { apo_druid: apo,
@@ -55,7 +58,7 @@ module Was
 
       def parse_collection_json(collection_json)
         collections_list = []
-        unless collection_json.nil?
+        if collection_json.present?
           collection_json.each do |collection|
             if collection['title'].length > 30 then
               collection_title = "#{collection['title'][0..30]} ..."
@@ -70,7 +73,7 @@ module Was
 
       def parse_items_json(items_json)
         items_list = []
-        unless items_json.nil?
+        if items_json.present?
           items_json.each do |item|
             items_list.push(title: item['title'], druid: item['druid'])
           end

--- a/spec/utilities/dor_utilities_spec.rb
+++ b/spec/utilities/dor_utilities_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Was::Utilities::DorUtilities do
+  let(:druid) { 'druid:aa111aa1111' }
+  subject { described_class.new(druid) }
+  context '#read_apo_data' do
+    it 'throws an error when reading APO data fails unexpectedly' do
+      expect(RestClient).to receive(:get).and_raise(RestClient::Exception)
+      expect(Rails.logger).to receive(:fatal).with(/Error in reading apo list/)
+      expect(subject.get_collections_list).to be_empty
+    end
+  end
+  context '#get_collections_list' do
+    it 'throws an error when APO data is blank' do
+      expect(subject).to receive(:read_apo_data).and_return({})
+      expect { subject.get_collections_list }.to raise_error(RuntimeError, /Missing adminpolicies/)
+    end
+  end
+  context '#get_items_list' do
+    it 'throws an error when APO data is blank' do
+      expect(subject).to receive(:read_apo_data).and_return({})
+      expect { subject.get_items_list }.to raise_error(RuntimeError, /Missing adminpolicies/)
+    end
+  end
+end


### PR DESCRIPTION
This PR throws an explicit error unless `apo_info_json['adminpolicies'].present?` in the APO fetcher utility. Also added a spec for the `Was::Utilities::DorUtilities` class, which didn't have one.

This PR is connected to https://github.com/sul-dlss/was-registrar/issues/11