### PR TITLE
disable crawl routes and Manage crawl tab

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -6,7 +6,7 @@
 WAS Registrar is responsible of faciltating the web archiving service object registration process. It has two main parts
 
 === Crawl registration
-It reads the available crawl jobs and gives the service manager the ability to register the object.
+This functionality has been removed pending implementation of APO retrieval. (It reads the available crawl jobs and gives the service manager the ability to register the object.)
 
 === Seed registration
 It reads two files that represents the main seed URI list and its related XML metadata. It gives the service manager the ability to register the seed object.

--- a/app/assets/javascripts/registrar.js.erb
+++ b/app/assets/javascripts/registrar.js.erb
@@ -1,10 +1,10 @@
 
 function register_item(id,type) {
-	
+
 		if(type == "seed"){
 			url = "/seeds/register_one_item";
-		} else if(type == "crawl"){
-			url = "/crawls/register_one_item"
+		// } else if(type == "crawl"){
+		// 	url = "/crawls/register_one_item"
 		}
 		q.queue({
  			async: true,
@@ -20,32 +20,32 @@ function register_item(id,type) {
 
 			beforeSend: function(  ) {
 		    	register_status_id = "register_status_"+id;
-		 		$('#'+register_status_id).addClass("glyphicon glyphicon-refresh glyphicon-refresh-animate") 
+		 		$('#'+register_status_id).addClass("glyphicon glyphicon-refresh glyphicon-refresh-animate")
 		    },
 		    success: function( result ) {
 				register_status_id = "register_status_"+id;
-				
+
 				if(result.status=='true'){
-			 		$('#'+register_status_id).removeClass("glyphicon glyphicon-refresh glyphicon-refresh-animate") 
-			 		$('#'+register_status_id).addClass("glyphicon glyphicon-ok text-success") 
-	
+			 		$('#'+register_status_id).removeClass("glyphicon glyphicon-refresh glyphicon-refresh-animate")
+			 		$('#'+register_status_id).addClass("glyphicon glyphicon-ok text-success")
+
 					druid_span_id = "druid_span_"+id;
 					druid_link = "<a href='<%= Rails.configuration.argo_catalog%>"+result.druid+"' target='_blank' >"+result.druid+"</a>";
 					$('#'+druid_span_id).html(  druid_link);
 				} else{
 					register_status_id = "register_status_"+id;
-			 		$('#'+register_status_id).removeClass("glyphicon glyphicon-refresh glyphicon-refresh-animate") 
-			 		$('#'+register_status_id).addClass("glyphicon glyphicon-remove text-danger") 
+			 		$('#'+register_status_id).removeClass("glyphicon glyphicon-refresh glyphicon-refresh-animate")
+			 		$('#'+register_status_id).addClass("glyphicon glyphicon-remove text-danger")
 			 		$('#message_'+id).parent().removeClass('hidden');
 			 		$('#message_'+id).html(result.message);
 				}
 		    },
-		 
+
 		    error: function( xhr, status, errorThrown ) {
 		 		console.log('ajax fail for id '+id)
 		 		register_status_id = "register_status_"+id;
-		 		$('#'+register_status_id).removeClass("glyphicon glyphicon-refresh glyphicon-refresh-animate") 
-		 		$('#'+register_status_id).addClass("glyphicon glyphicon-remove text-danger") 
+		 		$('#'+register_status_id).removeClass("glyphicon glyphicon-refresh glyphicon-refresh-animate")
+		 		$('#'+register_status_id).addClass("glyphicon glyphicon-remove text-danger")
 		 		$('#message_'+id).parent().removeClass('hidden');
 		 		$('#message_'+id).html(errorThrown);
 		    },

--- a/app/controllers/crawls_controller.rb
+++ b/app/controllers/crawls_controller.rb
@@ -2,6 +2,8 @@ require 'was/utilities/dor_utilities'
 require 'was/registrar/sync_crawl_object'
 require 'was/registrar/register_crawl_object'
 
+# TODO: Note that all of this code is disabled in config/routes.rb
+
 class CrawlsController < ApplicationController
   layout 'application'
   respond_to :html, :json

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
 
 
 
-  
+
     <nav class="navbar navbar-inverse navbar-fixed-top" role="navigation">
       <div class="container">
         <div class="navbar-header">
@@ -39,7 +39,7 @@
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
             <li id="seeds-navbar"><a href="/seeds/index">Manage seeds</a></li>
-            <li id="crawl-navbar"><a href="/crawls/index">Manage crawls</a></li>
+            <!-- <li id="crawl-navbar"><a href="/crawls/index">Manage crawls</a></li> -->
           </ul>
         </div><!--/.nav-collapse -->
       </div>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,15 +75,14 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-  
-  
-   # Application specific 
+
+
+   # Application specific
   config.apo = ''
   config.staging_path = "./"
-  
-  
+
+
   config.service_root = ''
   config.argo_catalog = ''
   config.crawl_stage = ''
-  config.apo_list_call = ''
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,14 +36,13 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
   config.autoload_paths += %W(#{config.root}/lib/importer)
 
-  # Application specific 
- # Application specific 
+  # Application specific
+ # Application specific
   config.apo = ''
   config.staging_path = "./"
-  
-  
+
+
   config.service_root = ''
   config.argo_catalog = ''
   config.crawl_stage = ''
-  config.apo_list_call = ''
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,13 @@
 Rails.application.routes.draw do
 
- 
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 
   # You can have the root of your site routed with "root"
   root 'seeds#index'
 
-  get 'crawls/index' => 'crawls#index'
-  match ':controller(/:action(/:id))', :via=>  [:get, :post]
+  match ':controller(/:action(/:id))', :controller => /(seeds|importer)/, :via=>  [:get, :post]
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'
 

--- a/lib/was/utilities/dor_utilities.rb
+++ b/lib/was/utilities/dor_utilities.rb
@@ -44,19 +44,7 @@ module Was
       private
 
       def read_apo_data(apo)
-        begin
-          resource = RestClient::Resource.new(
-            Rails.configuration.apo_list_call, timeout: 60, open_timeout: 60
-          )
-          response = resource[apo].get
-          Rails.logger.debug response.inspect
-          return JSON.parse(response.body)
-        rescue RestClient::Exception => e
-          Rails.logger.fatal 'Error in reading apo list: ' + e.inspect
-          Rails.logger.fatal e.backtrace.join("\n") if e.backtrace.present?
-          raise
-        end
-        nil
+        fail NotImplementedError, 'APO retrieval via dor_fetcher is no longer supported'
       end
 
       def parse_collection_json(collection_json)


### PR DESCRIPTION
@ndushay This PR fixes #30 and fixes #29, and is an alternative to PR #31. It does not remove any code, except for the dor-fetcher of the APO, and simply disables the `crawl` routes.

Deployed to stage.