### PR TITLE
rails env files: add timestamp and PID to logs

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,17 +32,18 @@ Rails.application.configure do
   # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
 
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
   config.autoload_paths += %W(#{config.root}/lib/importer)
 
-  # Application specific 
-  config.apo = ''
+  # Application specific
+  config.crawl_apos = ''
+  config.seed_apo = ''
   config.staging_path = "./"
-  
-  
   config.service_root = ''
   config.argo_catalog = ''
   config.crawl_stage = ''
-  config.apo_list_call = ''
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,12 +76,10 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-
-   # Application specific
-  config.apo = ''
+  # Application specific
+  config.crawl_apos = ''
+  config.seed_apo = ''
   config.staging_path = "./"
-
-
   config.service_root = ''
   config.argo_catalog = ''
   config.crawl_stage = ''

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -32,16 +32,17 @@ Rails.application.configure do
   # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
 
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
   config.autoload_paths += %W(#{config.root}/lib/importer)
 
   # Application specific
- # Application specific
-  config.apo = ''
+  config.crawl_apos = ''
+  config.seed_apo = ''
   config.staging_path = "./"
-
-
   config.service_root = ''
   config.argo_catalog = ''
   config.crawl_stage = ''


### PR DESCRIPTION
currently the production.rb file is in shared/config but we'll want this change when we switch to shared_configs #24.
