### PR TITLE
unpin mysql2 gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 5.0'
 gem 'responders' # controller-level `respond_to' feature now in `responders` gem as of rails 4.2
-gem 'mysql2', '~> 0.3.18'
+gem 'mysql2'
 gem 'sass-rails'
 gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,7 +180,7 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     multi_json (1.13.1)
-    mysql2 (0.3.21)
+    mysql2 (0.5.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (5.0.1)
@@ -348,7 +348,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   listen
-  mysql2 (~> 0.3.18)
+  mysql2
   nokogiri
   okcomputer
   pry-byebug


### PR DESCRIPTION
deploying gave this error:

```
Gem::LoadError: can't activate mysql2 (< 0.6.0, >= 0.4.4), already activated mysql2-0.3.21. Make sure all dependencies are added to Gemfile.
/usr/local/rvm/gems/ruby-2.3.4@global/gems/bundler-1.14.6/lib/bundler/rubygems_integration.rb:361:in `block (2 levels) in replace_gem'
/opt/app/was/was-registrar/shared/bundle/ruby/2.3.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/mysql2_adapter.rb:6:in `<top (required)>'
```

so unpinning mysql2 gem -- i'm guessing it was pinned for no good reason