### PR TITLE
Remove therubyracer in favor of nodejs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,6 @@ gem 'mysql2'
 gem 'sass-rails'
 gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails'
-gem 'therubyracer',  platforms: :ruby
-gem 'execjs'
 gem 'config' # rails environment specific configs
 
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,6 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.6)
-    libv8 (3.16.14.19)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -238,7 +237,6 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rdoc (4.3.0)
-    ref (2.0.0)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -307,9 +305,6 @@ GEM
       net-ssh (>= 2.8.0)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -345,7 +340,6 @@ DEPENDENCIES
   coveralls
   dlss-capistrano
   equivalent-xml
-  execjs
   honeybadger
   jbuilder (~> 2.0)
   jquery-rails
@@ -364,9 +358,8 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   spring
   sqlite3
-  therubyracer
   turbolinks
   uglifier (>= 1.3.0)
 
 BUNDLED WITH
-   1.16.3
+   1.16.4


### PR DESCRIPTION
therubyracer has been abandoned by Rails: https://github.com/rails/rails/pull/29285
It is no longer compatible with the latest version of
autoprefixer-rails: https://github.com/ai/autoprefixer-rails/issues/137