### PR TITLE
travis: only use current deployed ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.3.4
   - 2.5.3
 
 language: ruby


### PR DESCRIPTION
ruby version updated on VMs and cap deployed to those VMs;  only need that ruby version.