### PR TITLE
Remove token_header keyword arg when configuring dor-services-client

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    airbrussh (1.3.3)
+    airbrussh (1.3.4)
       sshkit (>= 1.6.1, != 1.7.0)
     arel (9.0.0)
     ast (2.4.0)
@@ -83,9 +83,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
-    cocina-models (0.1.0)
-      dry-struct
-      dry-types
+    cocina-models (0.1.2)
+      dry-struct (~> 1.0)
+      dry-types (~> 1.1)
       zeitwerk (~> 2.1)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
@@ -112,14 +112,14 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.3.2)
-    dor-services-client (2.5.0)
+    dor-services-client (2.6.2)
       activesupport (>= 4.2, < 7)
       cocina-models (~> 0.1.0)
       faraday (~> 0.15)
       moab-versioning (~> 4.0)
       nokogiri (~> 1.8)
       zeitwerk (~> 2.1)
-    dor-workflow-client (3.4.2)
+    dor-workflow-client (3.7.0)
       activesupport (>= 3.2.1, < 7)
       deprecation (>= 0.99.0)
       faraday (~> 0.9, >= 0.9.2)
@@ -143,7 +143,7 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.2)
       dry-equalizer (~> 0.2)
-    dry-schema (1.3.3)
+    dry-schema (1.3.4)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.8, >= 0.8.3)
       dry-core (~> 0.4)
@@ -221,7 +221,7 @@ GEM
       nokogiri (~> 1.5)
     okcomputer (1.17.4)
     parallel (1.17.0)
-    parser (2.6.4.0)
+    parser (2.6.4.1)
       ast (~> 2.4.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -387,4 +387,4 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
 
 BUNDLED WITH
-   1.17.3
+   1.16.4

--- a/config/initializers/dor_services_client.rb
+++ b/config/initializers/dor_services_client.rb
@@ -2,5 +2,4 @@
 
 # Configure dor-services-client to use the dor-services URL
 Dor::Services::Client.configure(url: Settings.DOR_SERVICES.URL,
-                                token: Settings.DOR_SERVICES.TOKEN,
-                                token_header: Settings.DOR_SERVICES.TOKEN_HEADER)
+                                token: Settings.DOR_SERVICES.TOKEN)


### PR DESCRIPTION
This is no longer required, and in fact can break the client if the header value (from shared_configs) is unset. This is what broke the workflow service connection to dor-services-app.